### PR TITLE
Fix for iterator aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,6 @@
 
 2.0.0
 * allowing to create `ObjectArray` from iterators (iterable psuedo-type - https://www.php.net/manual/en/language.types.iterable.php)
+
+2.0.1
+* fix for `IteratorAggregate` iterable

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": [
     "MIT"
   ],
-  "version": "2.0.0",
+  "version": "2.0.1",
   "authors": [
     {
       "name": "Maciej Sławik",

--- a/src/ObjectArray.php
+++ b/src/ObjectArray.php
@@ -42,10 +42,10 @@ class ObjectArray implements Countable, ArrayAccess, Iterator
     public function __construct(string $type, iterable $objects = [])
     {
         $this->type = $type;
+        $this->iterator = new ArrayIterator();
         foreach ($objects as $object) {
-            $this->validateObjectType($object);
+            $this->add($object);
         }
-        $this->iterator = new ArrayIterator($objects);
     }
 
     /**

--- a/tests/Unit/ObjectArrayTest.php
+++ b/tests/Unit/ObjectArrayTest.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 
 namespace MSlwk\TypeSafeArray\Test\Unit;
 
+use ArrayAccess;
 use ArrayIterator;
 use DateTime;
 use DateTimeImmutable;
 use InvalidArgumentException;
+use IteratorAggregate;
 use MSlwk\TypeSafeArray\ObjectArray;
 use PHPUnit\Framework\TestCase;
 
@@ -121,12 +123,48 @@ class ObjectArrayTest extends TestCase
      */
     public function provideDifferentIterables(): array
     {
+        $iteratorAggregate = new class() implements IteratorAggregate, ArrayAccess {
+            private $innerIterator;
+            public function __construct()
+            {
+                $this->innerIterator = new ArrayIterator();
+            }
+
+            public function getIterator(): ArrayIterator
+            {
+                return $this->innerIterator;
+            }
+
+            public function offsetExists($offset): bool
+            {
+                return $this->innerIterator->offsetExists($offset);
+            }
+
+            public function offsetGet($offset)
+            {
+                return $this->innerIterator->offsetGet($offset);
+            }
+
+            public function offsetSet($offset, $value): void
+            {
+                $this->innerIterator->offsetSet($offset, $value);
+            }
+
+            public function offsetUnset($offset): void
+            {
+                $this->innerIterator->offsetUnset($offset);
+            }
+        };
+
         return [
             'plain_array' => [
                 []
             ],
             'iterator' => [
                 new ArrayIterator()
+            ],
+            'iterator-aggregate' => [
+                $iteratorAggregate
             ]
         ];
     }


### PR DESCRIPTION
Fix for ObjectArray creation, when iterable is of type IteratorAggregate + adding test case.
Instead of casting Iterators to array, now we iterate over any iterable and validate and try to add item one by one (more efficient in scope of memory). Final effect is the same, but it handles all types of iterable (calls getIterator method of IteratorAggregate) in the same way.